### PR TITLE
Change transactions amount type to int

### DIFF
--- a/library/session/src/main/java/io/snabble/pay/session/data/dto/TransactionDto.kt
+++ b/library/session/src/main/java/io/snabble/pay/session/data/dto/TransactionDto.kt
@@ -5,8 +5,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 internal data class TransactionDto(
-    @SerialName("amount") val amount: String,
-    @SerialName("currency") val currency: String,
+    @SerialName("amount") val amount: Int,
+    @SerialName("currencyCode") val currencyCode: String,
     @SerialName("id") val id: String,
     @SerialName("state") val state: TransactionStateDto,
 )

--- a/library/session/src/main/java/io/snabble/pay/session/data/mapper/TransactionMapper.kt
+++ b/library/session/src/main/java/io/snabble/pay/session/data/mapper/TransactionMapper.kt
@@ -11,7 +11,7 @@ internal class TransactionMapper(
     override fun map(from: TransactionDto): Transaction = with(from) {
         Transaction(
             amount = from.amount,
-            currency = from.currency,
+            currencyCode = from.currencyCode,
             id = from.id,
             state = stateMapper.map(state)
         )

--- a/library/session/src/main/java/io/snabble/pay/session/domain/model/Transaction.kt
+++ b/library/session/src/main/java/io/snabble/pay/session/domain/model/Transaction.kt
@@ -1,8 +1,8 @@
 package io.snabble.pay.session.domain.model
 
 data class Transaction(
-    val amount: String,
-    val currency: String,
+    val amount: Int,
+    val currencyCode: String,
     val id: String,
     val state: TransactionState,
 )

--- a/library/session/src/test/java/io/snabble/pay/session/data/mapper/TransactionMapperTest.kt
+++ b/library/session/src/test/java/io/snabble/pay/session/data/mapper/TransactionMapperTest.kt
@@ -21,7 +21,7 @@ internal class TransactionMapperTest : FreeSpec({
     "TransactionMapper should correctly map the" - {
 
         "amount" {
-            val expectedAmount = "7"
+            val expectedAmount = 7
             val tokenDto = mockk<TransactionDto>(relaxed = true) {
                 every { amount } returns expectedAmount
             }
@@ -31,15 +31,15 @@ internal class TransactionMapperTest : FreeSpec({
             sut.map(tokenDto).amount shouldBe expectedAmount
         }
 
-        "currency" {
-            val expectedCurrency = "EUR"
+        "currencyCode" {
+            val expectedCurrencyCode = "EUR"
             val tokenDto = mockk<TransactionDto>(relaxed = true) {
-                every { currency } returns expectedCurrency
+                every { currencyCode } returns expectedCurrencyCode
             }
 
             val sut = createSut()
 
-            sut.map(tokenDto).currency shouldBe expectedCurrency
+            sut.map(tokenDto).currencyCode shouldBe expectedCurrencyCode
         }
 
         "id" {


### PR DESCRIPTION
Change transactions amount type from `String` to `Int` and rename the _currency_ to _currencyCode_.
