### PR TITLE
Add whitespace for Qr-code

### DIFF
--- a/app/src/main/java/io/snabble/pay/app/domain/account/utils/QrCodeGenerator.kt
+++ b/app/src/main/java/io/snabble/pay/app/domain/account/utils/QrCodeGenerator.kt
@@ -30,7 +30,7 @@ class QrCodeGenerator {
         for (y in 0 until height) {
             for (x in 0 until width) {
                 pixels[y * width + x] =
-                    if (bitMapMatrix.get(x, y)) Color.BLACK else Color.TRANSPARENT
+                    if (bitMapMatrix.get(x, y)) Color.BLACK else Color.WHITE
             }
         }
 

--- a/app/src/main/java/io/snabble/pay/app/ui/widgets/accountcard/QrCodeImage.kt
+++ b/app/src/main/java/io/snabble/pay/app/ui/widgets/accountcard/QrCodeImage.kt
@@ -1,15 +1,22 @@
 package io.snabble.pay.app.ui.widgets.accountcard
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.LottieConstants
@@ -33,12 +40,19 @@ fun QrCodeImage(
         )
     } else {
         if (qrCodeToken != null) {
-            Image(
-                modifier = modifier,
-                bitmap = QrCodeGenerator.generateQrCode(qrCodeToken)
-                    .asImageBitmap(),
-                contentDescription = ""
-            )
+            Box(
+                modifier = modifier
+                    .clip(shape = RoundedCornerShape(8.dp))
+                    .background(color = Color.White),
+                contentAlignment = Alignment.Center
+            ) {
+                Image(
+                    modifier = Modifier.padding(4.dp),
+                    bitmap = QrCodeGenerator.generateQrCode(qrCodeToken)
+                        .asImageBitmap(),
+                    contentDescription = ""
+                )
+            }
         } else {
             val composition by rememberLottieComposition(
                 LottieCompositionSpec


### PR DESCRIPTION
### What's new?

White space has been added around the Qr-code to improve readability for scanners.

### How to test?

Launch the app, add a card and check Qr-code in light and dark mode