### PR TITLE
Update GitHub artifact and checkout action

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -20,7 +20,7 @@ jobs:
         run: ./gradlew ktlintCheck
 
       - name: Provide Ktlint Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Ktlint Results
           path: ./*/build/reports/ktlint/

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -20,7 +20,7 @@ jobs:
         run: ./gradlew detekt
 
       - name: Provide Detekt Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Detekt Results
           path: core/build/reports/detekt/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
         run: ./gradlew dokkaHtmlMultiModule
 
       - name: Provide Documentation as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Snabble Pay Documentation
           path: docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/publish_app_to_firebase.yml
+++ b/.github/workflows/publish_app_to_firebase.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/publish_app_to_firebase.yml
+++ b/.github/workflows/publish_app_to_firebase.yml
@@ -37,7 +37,7 @@ jobs:
         run: ./gradlew app:assembleRelease
 
       - name: Provide Release App APK as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Release App APK
           path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         run: ./gradlew test
 
       - name: Provide Unit Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results
           path: core/build/reports/tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup JDK 17
         uses: actions/setup-java@v3


### PR DESCRIPTION
GitHub artifact and checkout action has been updated to version 4.

Check if the piplines has been run w/ it successfully.
